### PR TITLE
Implement modern realtime chat foundation with rooms, presence, and rich messaging

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,68 +1,26 @@
-<p align="center"><a href="https://laravel.com" target="_blank"><img src="https://raw.githubusercontent.com/laravel/art/master/logo-lockup/5%20SVG/2%20CMYK/1%20Full%20Color/laravel-logolockup-cmyk-red.svg" width="400"></a></p>
-<p>
-<img src="https://raw.githubusercontent.com/alicemalturan/laravel_realtimechat/main/ss1.png">
-</p>
-<p>
-<img src="https://raw.githubusercontent.com/alicemalturan/laravel_realtimechat/main/ss2.png">
-</p>
+# Laravel Realtime Chat
 
-<p align="center">
-<a href="https://travis-ci.org/laravel/framework"><img src="https://travis-ci.org/laravel/framework.svg" alt="Build Status"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/dt/laravel/framework" alt="Total Downloads"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/v/laravel/framework" alt="Latest Stable Version"></a>
-<a href="https://packagist.org/packages/laravel/framework"><img src="https://img.shields.io/packagist/l/laravel/framework" alt="License"></a>
-</p>
+Modernized realtime chat baseline with:
 
-## About Laravel
+- Auth flow (register/login/logout)
+- Multi-room messaging
+- Typing indicators
+- Presence heartbeat (online users)
+- Read receipts (sent/delivered/seen)
+- Emoji reactions
+- File/image attachments
+- Cursor pagination + infinite scroll
+- Optimistic UI and skeleton loaders
 
-Laravel is a web application framework with expressive, elegant syntax. We believe development must be an enjoyable and creative experience to be truly fulfilling. Laravel takes the pain out of development by easing common tasks used in many web projects, such as:
+## Run locally
 
-- [Simple, fast routing engine](https://laravel.com/docs/routing).
-- [Powerful dependency injection container](https://laravel.com/docs/container).
-- Multiple back-ends for [session](https://laravel.com/docs/session) and [cache](https://laravel.com/docs/cache) storage.
-- Expressive, intuitive [database ORM](https://laravel.com/docs/eloquent).
-- Database agnostic [schema migrations](https://laravel.com/docs/migrations).
-- [Robust background job processing](https://laravel.com/docs/queues).
-- [Real-time event broadcasting](https://laravel.com/docs/broadcasting).
+```bash
+cp .env.example .env
+php artisan key:generate
+php artisan migrate
+php artisan serve
+```
 
-Laravel is accessible, powerful, and provides tools required for large, robust applications.
+If using websockets, configure Pusher-compatible settings (Reverb or Soketi) in `.env`.
 
-## Learning Laravel
-
-Laravel has the most extensive and thorough [documentation](https://laravel.com/docs) and video tutorial library of all modern web application frameworks, making it a breeze to get started with the framework.
-
-If you don't feel like reading, [Laracasts](https://laracasts.com) can help. Laracasts contains over 1500 video tutorials on a range of topics including Laravel, modern PHP, unit testing, and JavaScript. Boost your skills by digging into our comprehensive video library.
-
-## Laravel Sponsors
-
-We would like to extend our thanks to the following sponsors for funding Laravel development. If you are interested in becoming a sponsor, please visit the Laravel [Patreon page](https://patreon.com/taylorotwell).
-
-### Premium Partners
-
-- **[Vehikl](https://vehikl.com/)**
-- **[Tighten Co.](https://tighten.co)**
-- **[Kirschbaum Development Group](https://kirschbaumdevelopment.com)**
-- **[64 Robots](https://64robots.com)**
-- **[Cubet Techno Labs](https://cubettech.com)**
-- **[Cyber-Duck](https://cyber-duck.co.uk)**
-- **[Many](https://www.many.co.uk)**
-- **[Webdock, Fast VPS Hosting](https://www.webdock.io/en)**
-- **[DevSquad](https://devsquad.com)**
-- **[Curotec](https://www.curotec.com/services/technologies/laravel/)**
-- **[OP.GG](https://op.gg)**
-
-## Contributing
-
-Thank you for considering contributing to the Laravel framework! The contribution guide can be found in the [Laravel documentation](https://laravel.com/docs/contributions).
-
-## Code of Conduct
-
-In order to ensure that the Laravel community is welcoming to all, please review and abide by the [Code of Conduct](https://laravel.com/docs/contributions#code-of-conduct).
-
-## Security Vulnerabilities
-
-If you discover a security vulnerability within Laravel, please send an e-mail to Taylor Otwell via [taylor@laravel.com](mailto:taylor@laravel.com). All security vulnerabilities will be promptly addressed.
-
-## License
-
-The Laravel framework is open-sourced software licensed under the [MIT license](https://opensource.org/licenses/MIT).
+See `docs/modern-chat-architecture.md` for stack/deployment decisions.

--- a/app/Events/MessageReactionUpdated.php
+++ b/app/Events/MessageReactionUpdated.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageReactionUpdated implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public int $roomId;
+    public int $messageId;
+
+    public function __construct(int $roomId, int $messageId)
+    {
+        $this->roomId = $roomId;
+        $this->messageId = $messageId;
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel('chat.room.' . $this->roomId);
+    }
+
+    public function broadcastAs()
+    {
+        return 'reaction.updated';
+    }
+}

--- a/app/Events/MessageReadUpdated.php
+++ b/app/Events/MessageReadUpdated.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace App\Events;
+
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageReadUpdated implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public int $roomId;
+    public int $messageId;
+    public int $userId;
+
+    public function __construct(int $roomId, int $messageId, int $userId)
+    {
+        $this->roomId = $roomId;
+        $this->messageId = $messageId;
+        $this->userId = $userId;
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel('chat.room.' . $this->roomId);
+    }
+
+    public function broadcastAs()
+    {
+        return 'message.read';
+    }
+}

--- a/app/Events/MessageSent.php
+++ b/app/Events/MessageSent.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\Message;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class MessageSent implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public int $roomId;
+    public array $message;
+
+    public function __construct(int $roomId, Message $message)
+    {
+        $this->roomId = $roomId;
+        $this->message = [
+            'id' => $message->id,
+            'body' => $message->body,
+            'meta' => $message->meta,
+            'created_at' => optional($message->created_at)->toIso8601String(),
+            'user' => ['id' => $message->user->id, 'username' => $message->user->username],
+            'reactions' => [],
+            'read_status' => 'sent',
+        ];
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel('chat.room.' . $this->roomId);
+    }
+
+    public function broadcastAs()
+    {
+        return 'message.sent';
+    }
+}

--- a/app/Events/PresenceUpdated.php
+++ b/app/Events/PresenceUpdated.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class PresenceUpdated implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public int $roomId;
+    public array $user;
+    public bool $online;
+
+    public function __construct(int $roomId, User $user, bool $online)
+    {
+        $this->roomId = $roomId;
+        $this->user = ['id' => $user->id, 'username' => $user->username];
+        $this->online = $online;
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel('chat.room.' . $this->roomId);
+    }
+
+    public function broadcastAs()
+    {
+        return 'presence.updated';
+    }
+}

--- a/app/Events/TypingStatusUpdated.php
+++ b/app/Events/TypingStatusUpdated.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Events;
+
+use App\Models\User;
+use Illuminate\Broadcasting\PrivateChannel;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class TypingStatusUpdated implements ShouldBroadcast
+{
+    use Dispatchable, SerializesModels;
+
+    public int $roomId;
+    public array $user;
+    public bool $typing;
+
+    public function __construct(int $roomId, User $user, bool $typing)
+    {
+        $this->roomId = $roomId;
+        $this->user = ['id' => $user->id, 'username' => $user->username];
+        $this->typing = $typing;
+    }
+
+    public function broadcastOn()
+    {
+        return new PrivateChannel('chat.room.' . $this->roomId);
+    }
+
+    public function broadcastAs()
+    {
+        return 'typing.updated';
+    }
+}

--- a/app/Http/Controllers/AuthController.php
+++ b/app/Http/Controllers/AuthController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\User;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Validation\Rule;
+
+class AuthController extends Controller
+{
+    public function showLogin()
+    {
+        return view('auth.login');
+    }
+
+    public function showRegister()
+    {
+        return view('auth.register');
+    }
+
+    public function login(Request $request)
+    {
+        $credentials = $request->validate([
+            'username' => ['required', 'string'],
+            'password' => ['required', 'string'],
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return back()->withErrors(['username' => 'Invalid credentials'])->withInput();
+        }
+
+        $request->session()->regenerate();
+
+        return redirect()->route('chat.index');
+    }
+
+    public function register(Request $request)
+    {
+        $data = $request->validate([
+            'username' => ['required', 'string', 'min:3', Rule::unique('users', 'username')],
+            'password' => ['required', 'string', 'min:8', 'confirmed'],
+        ]);
+
+        $user = User::create([
+            'username' => $data['username'],
+            'password' => bcrypt($data['password']),
+        ]);
+
+        Auth::login($user);
+
+        return redirect()->route('chat.index');
+    }
+
+    public function logout(Request $request)
+    {
+        Auth::logout();
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
+
+        return redirect()->route('login');
+    }
+}

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -1,0 +1,197 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Events\MessageReactionUpdated;
+use App\Events\MessageReadUpdated;
+use App\Events\MessageSent;
+use App\Events\PresenceUpdated;
+use App\Events\TypingStatusUpdated;
+use App\Models\ChatRoom;
+use App\Models\Message;
+use App\Models\MessageReaction;
+use App\Models\MessageReadReceipt;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+
+class ChatController extends Controller
+{
+    public function index(Request $request)
+    {
+        $user = $request->user();
+
+        $rooms = ChatRoom::withCount('users')
+            ->whereHas('users', fn ($q) => $q->where('users.id', $user->id))
+            ->orderBy('name')
+            ->get();
+
+        if ($rooms->isEmpty()) {
+            $room = ChatRoom::create([
+                'name' => 'General',
+                'slug' => 'general',
+                'type' => 'public',
+                'created_by' => $user->id,
+            ]);
+            $room->users()->attach($user->id, ['last_seen_at' => now()]);
+            $rooms = collect([$room]);
+        }
+
+        return view('chat.index', [
+            'rooms' => $rooms,
+            'activeRoomId' => (int) ($request->query('room') ?: $rooms->first()->id),
+        ]);
+    }
+
+    public function listMessages(Request $request, ChatRoom $room)
+    {
+        abort_unless($room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        $messages = Message::with(['user:id,username', 'reactions:user_id,message_id,emoji'])
+            ->where('chat_room_id', $room->id)
+            ->latest('id')
+            ->cursorPaginate(20)
+            ->through(function (Message $message) use ($request) {
+                return [
+                    'id' => $message->id,
+                    'body' => $message->body,
+                    'user' => $message->user,
+                    'meta' => $message->meta,
+                    'created_at' => $message->created_at?->toIso8601String(),
+                    'read_status' => $this->statusForMessage($message, $request->user()->id),
+                    'reactions' => $message->reactions->groupBy('emoji')->map->count(),
+                ];
+            });
+
+        return response()->json($messages);
+    }
+
+    public function sendMessage(Request $request, ChatRoom $room)
+    {
+        abort_unless($room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        $payload = $request->validate([
+            'body' => ['nullable', 'string', 'max:4000'],
+            'attachment' => ['nullable', 'file', 'max:5120', 'mimes:jpg,jpeg,png,gif,webp,pdf,doc,docx,zip'],
+        ]);
+
+        if (blank($payload['body'] ?? null) && !$request->hasFile('attachment')) {
+            return response()->json(['message' => 'Message cannot be empty'], 422);
+        }
+
+        $meta = [];
+        if ($request->hasFile('attachment')) {
+            $file = $request->file('attachment');
+            $path = $file->store('chat-uploads', 'public');
+            $meta['attachment'] = [
+                'name' => $file->getClientOriginalName(),
+                'url' => Storage::disk('public')->url($path),
+                'mime' => $file->getMimeType(),
+            ];
+        }
+
+        $message = Message::create([
+            'chat_room_id' => $room->id,
+            'user_id' => $request->user()->id,
+            'body' => $payload['body'] ?? null,
+            'meta' => $meta,
+            'delivered_at' => now(),
+        ]);
+
+        $message->load('user:id,username');
+
+        broadcast(new MessageSent($room->id, $message))->toOthers();
+
+        return response()->json(['message' => $message]);
+    }
+
+    public function typing(Request $request, ChatRoom $room)
+    {
+        abort_unless($room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        $request->validate(['typing' => ['required', 'boolean']]);
+
+        broadcast(new TypingStatusUpdated($room->id, $request->user(), (bool) $request->boolean('typing')))->toOthers();
+
+        return response()->noContent();
+    }
+
+    public function presence(Request $request, ChatRoom $room)
+    {
+        abort_unless($room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        $room->users()->updateExistingPivot($request->user()->id, ['last_seen_at' => now()]);
+        broadcast(new PresenceUpdated($room->id, $request->user(), true))->toOthers();
+
+        return response()->json(['ok' => true]);
+    }
+
+    public function addReaction(Request $request, Message $message)
+    {
+        abort_unless($message->room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        $payload = $request->validate(['emoji' => ['required', 'string', 'max:16']]);
+
+        MessageReaction::firstOrCreate([
+            'message_id' => $message->id,
+            'user_id' => $request->user()->id,
+            'emoji' => $payload['emoji'],
+        ]);
+
+        broadcast(new MessageReactionUpdated($message->chat_room_id, $message->id))->toOthers();
+
+        return response()->noContent();
+    }
+
+    public function markAsRead(Request $request, Message $message)
+    {
+        abort_unless($message->room->users()->where('user_id', $request->user()->id)->exists(), 403);
+
+        MessageReadReceipt::updateOrCreate(
+            ['message_id' => $message->id, 'user_id' => $request->user()->id],
+            ['delivered_at' => now(), 'read_at' => now()]
+        );
+
+        $message->update(['seen_at' => now()]);
+        broadcast(new MessageReadUpdated($message->chat_room_id, $message->id, $request->user()->id))->toOthers();
+
+        return response()->noContent();
+    }
+
+    public function createRoom(Request $request)
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:100'],
+            'type' => ['required', 'in:public,private'],
+        ]);
+
+        $room = DB::transaction(function () use ($data, $request) {
+            $room = ChatRoom::create([
+                'name' => $data['name'],
+                'slug' => Str::slug($data['name']) . '-' . Str::random(6),
+                'type' => $data['type'],
+                'created_by' => $request->user()->id,
+            ]);
+
+            $room->users()->attach($request->user()->id, ['last_seen_at' => now()]);
+
+            return $room;
+        });
+
+        return redirect()->route('chat.index', ['room' => $room->id]);
+    }
+
+    private function statusForMessage(Message $message, int $userId): string
+    {
+        if ($message->seen_at) {
+            return 'seen';
+        }
+
+        if ($message->delivered_at) {
+            return 'delivered';
+        }
+
+        return $message->user_id === $userId ? 'sent' : 'delivered';
+    }
+}

--- a/app/Models/ChatRoom.php
+++ b/app/Models/ChatRoom.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class ChatRoom extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['name', 'slug', 'type', 'created_by'];
+
+    public function users()
+    {
+        return $this->belongsToMany(User::class)
+            ->withPivot(['last_read_at', 'last_seen_at'])
+            ->withTimestamps();
+    }
+
+    public function messages()
+    {
+        return $this->hasMany(Message::class);
+    }
+}

--- a/app/Models/Message.php
+++ b/app/Models/Message.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Message extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['chat_room_id', 'user_id', 'body', 'meta', 'delivered_at', 'seen_at'];
+
+    protected $casts = [
+        'meta' => 'array',
+        'delivered_at' => 'datetime',
+        'seen_at' => 'datetime',
+    ];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+
+    public function room()
+    {
+        return $this->belongsTo(ChatRoom::class, 'chat_room_id');
+    }
+
+    public function reactions()
+    {
+        return $this->hasMany(MessageReaction::class);
+    }
+
+    public function readReceipts()
+    {
+        return $this->hasMany(MessageReadReceipt::class);
+    }
+}

--- a/app/Models/MessageReaction.php
+++ b/app/Models/MessageReaction.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MessageReaction extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['message_id', 'user_id', 'emoji'];
+
+    public function user()
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/MessageReadReceipt.php
+++ b/app/Models/MessageReadReceipt.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class MessageReadReceipt extends Model
+{
+    use HasFactory;
+
+    protected $fillable = ['message_id', 'user_id', 'delivered_at', 'read_at'];
+
+    protected $casts = [
+        'delivered_at' => 'datetime',
+        'read_at' => 'datetime',
+    ];
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2,7 +2,6 @@
 
 namespace App\Models;
 
-use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
@@ -11,33 +10,22 @@ class User extends Authenticatable
 {
     use HasFactory, Notifiable;
 
-    /**
-     * The attributes that are mass assignable.
-     *
-     * @var array
-     */
     protected $fillable = [
-        'name',
-        'email',
+        'username',
         'password',
     ];
 
-    /**
-     * The attributes that should be hidden for arrays.
-     *
-     * @var array
-     */
     protected $hidden = [
         'password',
         'remember_token',
     ];
 
-    /**
-     * The attributes that should be cast to native types.
-     *
-     * @var array
-     */
-    protected $casts = [
-        'email_verified_at' => 'datetime',
-    ];
+    protected $casts = [];
+
+    public function rooms()
+    {
+        return $this->belongsToMany(ChatRoom::class)
+            ->withPivot(['last_read_at', 'last_seen_at'])
+            ->withTimestamps();
+    }
 }

--- a/database/migrations/2026_03_03_000001_create_chat_rooms_table.php
+++ b/database/migrations/2026_03_03_000001_create_chat_rooms_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChatRoomsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('chat_rooms', function (Blueprint $table) {
+            $table->id();
+            $table->string('name');
+            $table->string('slug')->unique();
+            $table->enum('type', ['public', 'private'])->default('public');
+            $table->foreignId('created_by')->constrained('users')->cascadeOnDelete();
+            $table->timestamps();
+
+            $table->index(['type', 'created_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('chat_rooms');
+    }
+}

--- a/database/migrations/2026_03_03_000002_create_chat_room_user_table.php
+++ b/database/migrations/2026_03_03_000002_create_chat_room_user_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateChatRoomUserTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('chat_room_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_room_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('last_read_at')->nullable();
+            $table->timestamp('last_seen_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['chat_room_id', 'user_id']);
+            $table->index(['user_id', 'last_seen_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('chat_room_user');
+    }
+}

--- a/database/migrations/2026_03_03_000003_create_messages_table.php
+++ b/database/migrations/2026_03_03_000003_create_messages_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessagesTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('messages', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('chat_room_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->text('body')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamp('seen_at')->nullable();
+            $table->timestamps();
+
+            $table->index(['chat_room_id', 'id']);
+            $table->index(['chat_room_id', 'created_at']);
+            $table->index(['user_id', 'created_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('messages');
+    }
+}

--- a/database/migrations/2026_03_03_000004_create_message_reactions_table.php
+++ b/database/migrations/2026_03_03_000004_create_message_reactions_table.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessageReactionsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('message_reactions', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('emoji', 16);
+            $table->timestamps();
+
+            $table->unique(['message_id', 'user_id', 'emoji']);
+            $table->index(['message_id', 'emoji']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('message_reactions');
+    }
+}

--- a/database/migrations/2026_03_03_000005_create_message_read_receipts_table.php
+++ b/database/migrations/2026_03_03_000005_create_message_read_receipts_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateMessageReadReceiptsTable extends Migration
+{
+    public function up()
+    {
+        Schema::create('message_read_receipts', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('message_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamp('delivered_at')->nullable();
+            $table->timestamp('read_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(['message_id', 'user_id']);
+            $table->index(['user_id', 'read_at']);
+        });
+    }
+
+    public function down()
+    {
+        Schema::dropIfExists('message_read_receipts');
+    }
+}

--- a/docs/modern-chat-architecture.md
+++ b/docs/modern-chat-architecture.md
@@ -1,0 +1,43 @@
+# Modern Realtime Chat Stack (Laravel)
+
+## Stack Decision
+
+- **Backend:** Laravel 11 target (this repository currently demonstrates the architecture on Laravel 8 codebase).
+- **Realtime transport:** **Laravel Reverb** (primary) or **Soketi** (drop-in Pusher protocol alternative).
+- **Frontend:** Vue 3 + Inertia or React + Inertia; this implementation uses Blade + Alpine for lightweight migration.
+- **UI system:** Tailwind CSS + Headless UI patterns.
+- **Media:** S3-compatible object storage with signed URLs; local disk used in this demo.
+- **Performance:** Redis queues + Horizon, Octane (Swoole/RoadRunner), DB indexing and cursor pagination.
+- **Deployment:** Forge (VM) or Vapor (serverless), TLS everywhere, WSS-only in production.
+
+## Implemented in this repository
+
+- Multi-room chat schema (`chat_rooms`, `chat_room_user`, `messages`, `message_reactions`, `message_read_receipts`).
+- Cursor-based message pagination and infinite scroll endpoint.
+- Typing indicator events with debounce-friendly endpoint.
+- Presence heartbeat endpoint for online/offline state.
+- Read receipts with delivered/seen timestamps.
+- Emoji reactions per message.
+- Attachment upload endpoint (image/document).
+- Optimistic message rendering in UI.
+- Skeleton loading state in UI.
+
+## Reverb/Soketi setup notes
+
+1. For **Laravel 11 + Reverb**:
+   - Install: `composer require laravel/reverb`
+   - Publish config and set `BROADCAST_CONNECTION=reverb`.
+   - Route auth via `/broadcasting/auth` and private channels `chat.room.{id}`.
+2. For **Soketi**:
+   - Keep `BROADCAST_CONNECTION=pusher`.
+   - Point `PUSHER_HOST`, `PUSHER_PORT`, `PUSHER_SCHEME` to Soketi.
+3. Enforce WSS in production and disable plaintext WS outside local dev.
+
+## Security & scale checklist
+
+- Add per-user send throttles via `RateLimiter` (messages/minute).
+- Encrypt sensitive payloads (application-level encryption for private rooms).
+- Queue heavy tasks: notifications, previews, virus scans.
+- Add compound indexes for unread scans and room timelines (already included in migrations).
+- Move uploads to S3 and serve via CloudFront.
+

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -1,0 +1,28 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Login | Realtime Chat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6">
+<div class="w-full max-w-md rounded-2xl border border-slate-800 bg-slate-900 p-6 shadow-2xl">
+    <h1 class="text-2xl font-semibold mb-6">Sign in</h1>
+    @if ($errors->any())
+        <div class="mb-4 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-300">{{ $errors->first() }}</div>
+    @endif
+    <form method="post" action="{{ route('login.store') }}" class="space-y-4">
+        @csrf
+        <label class="block text-sm">Username
+            <input name="username" required class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2" value="{{ old('username') }}">
+        </label>
+        <label class="block text-sm">Password
+            <input type="password" name="password" required class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2">
+        </label>
+        <button class="w-full rounded-lg bg-indigo-500 hover:bg-indigo-400 px-4 py-2 font-medium">Login</button>
+    </form>
+    <p class="mt-4 text-sm text-slate-400">No account? <a class="text-indigo-400" href="{{ route('register') }}">Create one</a></p>
+</div>
+</body>
+</html>

--- a/resources/views/auth/register.blade.php
+++ b/resources/views/auth/register.blade.php
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Register | Realtime Chat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="min-h-screen bg-slate-950 text-slate-100 flex items-center justify-center p-6">
+<div class="w-full max-w-md rounded-2xl border border-slate-800 bg-slate-900 p-6 shadow-2xl">
+    <h1 class="text-2xl font-semibold mb-6">Create account</h1>
+    @if ($errors->any())
+        <div class="mb-4 rounded-lg border border-rose-500/30 bg-rose-500/10 p-3 text-sm text-rose-300">{{ $errors->first() }}</div>
+    @endif
+    <form method="post" action="{{ route('register.store') }}" class="space-y-4">
+        @csrf
+        <label class="block text-sm">Username
+            <input name="username" required class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2" value="{{ old('username') }}">
+        </label>
+        <label class="block text-sm">Password
+            <input type="password" name="password" required class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2">
+        </label>
+        <label class="block text-sm">Confirm password
+            <input type="password" name="password_confirmation" required class="mt-1 w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2">
+        </label>
+        <button class="w-full rounded-lg bg-indigo-500 hover:bg-indigo-400 px-4 py-2 font-medium">Register</button>
+    </form>
+    <p class="mt-4 text-sm text-slate-400">Already registered? <a class="text-indigo-400" href="{{ route('login') }}">Sign in</a></p>
+</div>
+</body>
+</html>

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -1,0 +1,164 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="csrf-token" content="{{ csrf_token() }}">
+    <title>Realtime Chat</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/axios/dist/axios.min.js"></script>
+    <script src="https://js.pusher.com/8.2.0/pusher.min.js"></script>
+    <script src="https://unpkg.com/laravel-echo/dist/echo.iife.js"></script>
+</head>
+<body class="h-screen bg-slate-950 text-slate-100" x-data="chatApp()" x-init="init()">
+<div class="flex h-full">
+    <aside class="w-72 border-r border-slate-800 p-4 space-y-4 bg-slate-900/80">
+        <div class="flex justify-between items-center">
+            <h1 class="font-semibold text-lg">Rooms</h1>
+            <form method="post" action="{{ route('logout') }}">@csrf<button class="text-xs text-slate-400">Logout</button></form>
+        </div>
+        <div class="space-y-2 max-h-[60vh] overflow-y-auto">
+            @foreach($rooms as $room)
+                <button @click="switchRoom({{ $room->id }})" class="w-full text-left rounded-lg px-3 py-2" :class="activeRoom==={{ $room->id }} ? 'bg-indigo-500/20 border border-indigo-400/30':'bg-slate-800/50'">
+                    <p class="font-medium">{{ $room->name }}</p>
+                    <p class="text-xs text-slate-400">{{ $room->users_count }} members</p>
+                </button>
+            @endforeach
+        </div>
+        <form method="post" action="{{ route('rooms.store') }}" class="space-y-2">
+            @csrf
+            <input name="name" required placeholder="New room" class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"/>
+            <select name="type" class="w-full rounded-lg border border-slate-700 bg-slate-950 px-3 py-2 text-sm"><option value="public">Public</option><option value="private">Private</option></select>
+            <button class="w-full rounded-lg bg-indigo-500 py-2 text-sm">Create room</button>
+        </form>
+    </aside>
+
+    <main class="flex-1 flex flex-col">
+        <header class="border-b border-slate-800 px-6 py-3 flex justify-between"><div>Room #<span x-text="activeRoom"></span></div><div class="text-sm text-emerald-400" x-text="onlineText"></div></header>
+
+        <section id="messages" @scroll.passive="onScroll" class="flex-1 overflow-y-auto px-6 py-4 space-y-3">
+            <template x-if="loading">
+                <div class="space-y-3 animate-pulse"><div class="h-16 rounded-lg bg-slate-800"></div><div class="h-16 rounded-lg bg-slate-800"></div></div>
+            </template>
+            <template x-for="message in messages" :key="message.id">
+                <article class="max-w-2xl" :class="message.user.id === me.id ? 'ml-auto text-right' : ''">
+                    <div class="inline-block rounded-2xl px-4 py-2" :class="message.user.id === me.id ? 'bg-indigo-500/30':'bg-slate-800'">
+                        <p class="text-xs text-slate-400" x-text="message.user.username"></p>
+                        <p x-text="message.body"></p>
+                        <template x-if="message.meta && message.meta.attachment">
+                            <a :href="message.meta.attachment.url" target="_blank" class="text-xs text-indigo-300 underline" x-text="message.meta.attachment.name"></a>
+                        </template>
+                        <div class="mt-1 text-xs text-slate-500" x-text="message.read_status"></div>
+                        <div class="mt-1 flex gap-1" :class="message.user.id===me.id?'justify-end':''">
+                            <template x-for="(count, emoji) in message.reactions"><button @click="react(message.id, emoji)" class="text-xs bg-slate-700 rounded px-1" x-text="emoji + ' ' + count"></button></template>
+                            <button @click="react(message.id,'👍')" class="text-xs">👍</button>
+                        </div>
+                    </div>
+                </article>
+            </template>
+            <div class="text-sm text-slate-400" x-text="typingText"></div>
+        </section>
+
+        <form @submit.prevent="send" class="border-t border-slate-800 p-4 sticky bottom-0 bg-slate-950">
+            <div class="flex gap-2">
+                <input @input.debounce.300ms="setTyping(true)" x-model="draft" placeholder="Write a message..." class="flex-1 rounded-xl border border-slate-700 bg-slate-900 px-4 py-3"/>
+                <input type="file" @change="pickFile" class="text-xs w-44"/>
+                <button class="rounded-xl bg-indigo-500 px-5">Send</button>
+            </div>
+        </form>
+    </main>
+</div>
+
+<script>
+function chatApp() {
+    return {
+        me: @json(auth()->user()),
+        activeRoom: {{ $activeRoomId }},
+        messages: [],
+        nextCursor: null,
+        loading: true,
+        draft: '',
+        file: null,
+        typers: new Set(),
+        online: new Set(),
+        echo: null,
+        init() {
+            axios.defaults.headers.common['X-CSRF-TOKEN'] = document.querySelector('meta[name="csrf-token"]').content;
+            this.bootEcho();
+            this.fetchMessages();
+            setInterval(() => this.pingPresence(), 20000);
+        },
+        bootEcho() {
+            this.echo = new window.Echo({
+                broadcaster: 'pusher',
+                key: '{{ env('PUSHER_APP_KEY', 'app-key') }}',
+                wsHost: '{{ env('PUSHER_HOST', '127.0.0.1') }}',
+                wsPort: {{ (int) env('PUSHER_PORT', 6001) }},
+                forceTLS: false,
+                enabledTransports: ['ws', 'wss'],
+                authEndpoint: '/broadcasting/auth',
+            });
+            this.subscribe();
+        },
+        subscribe() {
+            this.echo.private(`chat.room.${this.activeRoom}`)
+                .listen('.message.sent', (e) => { this.messages.push(e.message); this.scrollBottom(); })
+                .listen('.typing.updated', (e) => { e.typing ? this.typers.add(e.user.username) : this.typers.delete(e.user.username); })
+                .listen('.presence.updated', (e) => { e.online ? this.online.add(e.user.username) : this.online.delete(e.user.username); })
+                .listen('.message.read', (e) => {
+                    const msg = this.messages.find(m => m.id === e.messageId);
+                    if (msg) msg.read_status = 'seen';
+                });
+        },
+        async fetchMessages(cursor = null) {
+            this.loading = !cursor;
+            const { data } = await axios.get(`/rooms/${this.activeRoom}/messages`, { params: cursor ? { cursor } : {} });
+            const incoming = data.data.reverse();
+            this.messages = cursor ? [...incoming, ...this.messages] : incoming;
+            this.nextCursor = data.next_cursor;
+            this.loading = false;
+            if (!cursor) this.scrollBottom();
+            this.messages.filter(m => m.user.id !== this.me.id).forEach(m => axios.post(`/messages/${m.id}/read`));
+        },
+        async send() {
+            const optimistic = { id: Date.now(), body: this.draft, user: this.me, meta: {}, reactions: {}, read_status: 'sent' };
+            this.messages.push(optimistic);
+            this.scrollBottom();
+            const form = new FormData();
+            form.append('body', this.draft);
+            if (this.file) form.append('attachment', this.file);
+            this.draft = '';
+            this.file = null;
+            this.setTyping(false);
+            const { data } = await axios.post(`/rooms/${this.activeRoom}/messages`, form);
+            this.messages = this.messages.filter(m => m.id !== optimistic.id);
+            this.messages.push(data.message);
+            this.scrollBottom();
+        },
+        switchRoom(roomId) {
+            if (this.echo) this.echo.leave(`private-chat.room.${this.activeRoom}`);
+            this.activeRoom = roomId;
+            this.messages = [];
+            this.typers = new Set();
+            this.online = new Set();
+            this.subscribe();
+            this.fetchMessages();
+        },
+        onScroll(event) {
+            if (event.target.scrollTop <= 60 && this.nextCursor) this.fetchMessages(this.nextCursor);
+        },
+        scrollBottom() {
+            this.$nextTick(() => { const box = document.getElementById('messages'); box.scrollTop = box.scrollHeight; });
+        },
+        pickFile(event) { this.file = event.target.files[0] ?? null; },
+        setTyping(value) { axios.post(`/rooms/${this.activeRoom}/typing`, { typing: value }); },
+        pingPresence() { axios.post(`/rooms/${this.activeRoom}/presence`); },
+        react(messageId, emoji) { axios.post(`/messages/${messageId}/reactions`, { emoji }); },
+        get typingText() { return this.typers.size ? `${Array.from(this.typers).join(', ')} is typing...` : ''; },
+        get onlineText() { return `${this.online.size} online`; },
+    }
+}
+</script>
+</body>
+</html>

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -1,18 +1,10 @@
 <?php
 
+use App\Models\ChatRoom;
 use Illuminate\Support\Facades\Broadcast;
 
-/*
-|--------------------------------------------------------------------------
-| Broadcast Channels
-|--------------------------------------------------------------------------
-|
-| Here you may register all of the event broadcasting channels that your
-| application supports. The given channel authorization callbacks are
-| used to check if an authenticated user can listen to the channel.
-|
-*/
-
-Broadcast::channel('App.Models.User.{id}', function ($user, $id) {
-    return (int) $user->id === (int) $id;
+Broadcast::channel('chat.room.{roomId}', function ($user, $roomId) {
+    return ChatRoom::whereKey($roomId)
+        ->whereHas('users', fn ($query) => $query->where('users.id', $user->id))
+        ->exists();
 });

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,30 +1,26 @@
 <?php
 
-use App\Events\Chat;
+use App\Http\Controllers\AuthController;
+use App\Http\Controllers\ChatController;
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
+Route::middleware('guest')->group(function () {
+    Route::get('/login', [AuthController::class, 'showLogin'])->name('login');
+    Route::post('/login', [AuthController::class, 'login'])->name('login.store');
+    Route::get('/register', [AuthController::class, 'showRegister'])->name('register');
+    Route::post('/register', [AuthController::class, 'register'])->name('register.store');
+});
 
-Route::get('/', function () {
-    return view('chat');
-})->middleware('auth');
-Route::get('/login',function (){
-  return view('login');
-})->name('login');
-Route::get('/register',function (){
-    return view('register');
-})->name('register');
-Route::post('/login',[\App\Http\Controllers\Controller::class,'login']);
-Route::post('/register',[\App\Http\Controllers\Controller::class,'register']);
-Route::post('/chat',function(\Illuminate\Http\Request $req){
-    broadcast(new Chat($req->message));
+Route::middleware('auth')->group(function () {
+    Route::get('/', [ChatController::class, 'index'])->name('chat.index');
+    Route::post('/logout', [AuthController::class, 'logout'])->name('logout');
+
+    Route::post('/rooms', [ChatController::class, 'createRoom'])->name('rooms.store');
+    Route::get('/rooms/{room}/messages', [ChatController::class, 'listMessages'])->name('rooms.messages');
+    Route::post('/rooms/{room}/messages', [ChatController::class, 'sendMessage'])->name('rooms.messages.store');
+    Route::post('/rooms/{room}/typing', [ChatController::class, 'typing'])->name('rooms.typing');
+    Route::post('/rooms/{room}/presence', [ChatController::class, 'presence'])->name('rooms.presence');
+
+    Route::post('/messages/{message}/reactions', [ChatController::class, 'addReaction'])->name('messages.reactions');
+    Route::post('/messages/{message}/read', [ChatController::class, 'markAsRead'])->name('messages.read');
 });


### PR DESCRIPTION
### Motivation
- Modernize the existing prototype into a production-ready realtime chat foundation with multi-room support, presence/typing indicators, reactions, read receipts, and attachment uploads.
- Provide a clear architecture path for Laravel 11 + Reverb/Soketi and a lightweight frontend using Tailwind + Alpine (with notes for Vue/React + Inertia if desired).

### Description
- Added structured auth and chat endpoints with `AuthController` and `ChatController` implementing validated login/register/logout, room creation, cursor-paginated message listing, message send (with attachment handling), typing and presence endpoints, reactions, and read receipts.
- Introduced domain models and migrations for `chat_rooms`, `chat_room_user`, `messages`, `message_reactions`, and `message_read_receipts` with performance-oriented indexes and Eloquent relations (`ChatRoom`, `Message`, `MessageReaction`, `MessageReadReceipt`) and adjusted `User` to support rooms.
- Implemented broadcastable events for realtime UX: `MessageSent`, `TypingStatusUpdated`, `PresenceUpdated`, `MessageReactionUpdated`, and `MessageReadUpdated`, and updated `routes/channels.php` to authorize private per-room channels.
- Rebuilt UI using Tailwind + Alpine in `resources/views/chat/index.blade.php` with sidebar rooms, infinite scroll (cursor pagination), skeleton loaders, optimistic UI sends, file input, reactions display, typing and online indicators; added Tailwind-based auth views and documentation (`docs/modern-chat-architecture.md`) and updated `README.md`.

### Testing
- Ran PHP syntax checks (`php -l`) for new/modified files including `AuthController`, `ChatController`, models, routes and events; these returned no syntax errors (success).
- Attempted `composer install`, which failed because `composer.lock` packages are incompatible with the environment PHP (container PHP 8.5-dev), preventing full dependency install (failure).
- `php artisan route:list` could not run due to missing vendor autoload (consequence of failed `composer install`) so runtime/feature tests requiring framework bootstrap were not executed (skipped/failed).
- Executed a headless browser script to capture the UI artifact; the script ran and produced a screenshot, but the local app endpoint returned `Not Found` in this environment (artifact captured but the app was not serving).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a6a902ecb08333b7d4927f99a1d7a0)